### PR TITLE
Correção do link do LinkedIn

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       </li>
     </a>
 
-    <a href="linkedin.com/in/artur-neri/" target="_blank">
+    <a href="https://linkedin.com/in/artur-neri/" target="_blank">
       <li class="link">
         LinkedIn
       </li>


### PR DESCRIPTION
O link do LinkedIn estava sem o "https://".